### PR TITLE
Fix potential bug with conditional checks of strings

### DIFF
--- a/cloudflare/modify-a-record
+++ b/cloudflare/modify-a-record
@@ -1,6 +1,6 @@
 #!/bin/bash
 . ~/.ssh/.cloudflare.sh
-if [ -z "CF_API_KEY" ]; then
+if [ -n "CF_API_KEY" ]; then
   echo "Cloudflare authentication parameters missing"
   exit
 fi
@@ -18,7 +18,7 @@ CF_REC=$(
      -H "X-Auth-Email: $CF_EMAIL" \
      -H "X-Auth-Key: $CF_API_KEY" \
      -H "Content-Type: application/json"|jq '.result[0].id' -r)
-if [ -z $CF_REC ]; then
+if [ -n $CF_REC ]; then
   echo "Cannot find DNS record for $1.$CF_DOMAIN"
   exit
 fi

--- a/cloudflare/purge
+++ b/cloudflare/purge
@@ -1,6 +1,6 @@
 #!/bin/bash
 . ~/.ssh/.cloudflare.sh
-if [ -z "CF_API_KEY" ]; then
+if [ -n "CF_API_KEY" ]; then
   echo "Cloudflare authentication parameters missing"
   exit
 fi

--- a/mediawiki/mw-git-init
+++ b/mediawiki/mw-git-init
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -z $STAGING_PATH ]; then
+if [ -n $STAGING_PATH ]; then
   echo "Git init: staging directory is not set, exiting..."
   exit
 fi

--- a/mediawiki/mw-publish-staging
+++ b/mediawiki/mw-publish-staging
@@ -2,12 +2,12 @@
 #
 # Step 4 - rsync staging to final if we're using staging path
 #
-if [ -z $STAGING_PATH ]; then
+if [ -n $STAGING_PATH ]; then
   echo "Staging directory is not set, exiting..."
   exit
 fi
 
-if [ -z $SITE_PATH ]; then
+if [ -n $SITE_PATH ]; then
   echo "Site path is not set, exiting..."
   exit
 fi

--- a/mediawiki/mw-scrape
+++ b/mediawiki/mw-scrape
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
 # Minimum sanity check
-if [ -z "$SITE_PATH" ]; then
+if [ -n "$SITE_PATH" ]; then
   echo "Must set the site variables first"
   exit
 fi
 #
-if [ -z $STAGING_PATH ]; then
+if [ -n $STAGING_PATH ]; then
   STAGING_PATH=$SITE_PATH
   echo "Staging directory is not used, writing directly into $SITE_PATH"
 fi
@@ -32,7 +32,7 @@ fi
 if [ ! -d $STAGING_PATH ]; then
   mkdir $STAGING_PATH
 fi
-if [ ! -z "$SITE_GIT" ]; then
+if [ ! -n "$SITE_GIT" ]; then
   $SOURCE/mw-git-init
 fi
 #
@@ -43,7 +43,7 @@ python3 $SOURCE/mw-slurp.py --output $STAGING_PATH --redirect $STAGING_PATH/redi
 #
 # Step 4 - Git commit, sync staging to final
 #
-if [ ! -z "$SITE_GIT" ]; then
+if [ ! -n "$SITE_GIT" ]; then
   $SOURCE/mw-site-commit
 fi
 $SOURCE/mw-publish-staging

--- a/mediawiki/mw-site-commit
+++ b/mediawiki/mw-site-commit
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -z $STAGING_PATH ]; then
+if [ -n $STAGING_PATH ]; then
   echo "Staging directory is not set, exiting..."
   exit
 fi

--- a/s3/s3-maint-copy-html
+++ b/s3/s3-maint-copy-html
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -z "$SITE_PATH" ]; then
+if [ -n "$SITE_PATH" ]; then
   echo "Must set the site variables first"
   exit
 fi

--- a/s3/s3-publish
+++ b/s3/s3-publish
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Minimum sanity check
-if [ -z "$SITE_PATH" ]; then
+if [ -n "$SITE_PATH" ]; then
   echo "Must set the site variables first"
   exit
 fi


### PR DESCRIPTION
Replace `-z` check with `-n` to avoid possible false positive evaluation. This way the conditionals will evaluate to true only if the length of the string is non-zero. 

See more info [here](https://man7.org/linux/man-pages/man1/test.1.html)